### PR TITLE
Add bilingual landing page and compact layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,81 +18,84 @@
   <body class="grey lighten-4">
     <header
       class="green darken-1 white-text center-align"
-      style="padding: 60px 20px"
+      style="padding: 30px 20px"
     >
       <h1 class="flow-text" style="font-size: 2.5em; font-weight: bold">
-        Your AI Diet Companion on WhatsApp
+        Your AI Diet Companion on WhatsApp<br>
+        <span class="grey-text text-lighten-4">Teman Diet AI Anda di WhatsApp</span>
       </h1>
       <p class="flow-text">
-        Snap your meal. Know your nutrients. Stay balanced.
+        Snap your meal. Know your nutrients. Stay balanced.<br>
+        <span class="grey-text text-lighten-4">Ambil gambar hidangan anda. Ketahui nutriennya. Kekal seimbang.</span>
       </p>
-    </header>
 
     <main>
       <section class="container section">
-        <h2 class="center-align">How It Works</h2>
+        <h2 class="center-align">How It Works<br><span class="grey-text text-darken-1">Cara Ia Berfungsi</span></h2>
         <div class="row">
           <div class="col s12 m3 center-align">
             <i class="material-icons large green-text text-darken-2"
               >photo_camera</i
             >
-            <p>Upload a photo of your food via WhatsApp</p>
+            <p>Upload a photo of your food via WhatsApp<br><span class="grey-text text-darken-1">Muat naik gambar makanan anda melalui WhatsApp</span></p>
           </div>
           <div class="col s12 m3 center-align">
             <i class="material-icons large green-text text-darken-2"
               >insert_chart</i
             >
-            <p>Get instant nutrient breakdown</p>
+            <p>Get instant nutrient breakdown<br><span class="grey-text text-darken-1">Dapatkan pecahan nutrien segera</span></p>
           </div>
           <div class="col s12 m3 center-align">
             <i class="material-icons large green-text text-darken-2"
               >restaurant_menu</i
             >
-            <p>Receive daily meal suggestions to stay balanced</p>
+            <p>Receive daily meal suggestions to stay balanced<br><span class="grey-text text-darken-1">Terima cadangan hidangan harian untuk kekal seimbang</span></p>
           </div>
           <div class="col s12 m3 center-align">
             <i class="material-icons large green-text text-darken-2">book</i>
-            <p>Your diet diary is automatically updated</p>
+            <p>Your diet diary is automatically updated<br><span class="grey-text text-darken-1">Diari diet anda dikemas kini secara automatik</span></p>
           </div>
         </div>
       </section>
 
-      <section class="container section center-align">
-        <div id="qrcode" class="section"></div>
-        <div class="section">
-          <a
-            href="https://wa.me/0108426793"
-            target="_blank"
-            rel="noopener"
-            class="btn-large green"
-            >Chat on WhatsApp Now</a
-          >
-        </div>
-      </section>
+        <section class="container section">
+          <div class="row">
+            <div class="col s12 m6 center-align">
+              <div id="qrcode" class="section"></div>
+            </div>
+            <div class="col s12 m6 center-align">
+              <a href="https://wa.me/0108426793" target="_blank" rel="noopener" class="btn-large green">
+                Chat on WhatsApp Now<br><span class="grey-text text-darken-1">Bual di WhatsApp Sekarang</span>
+              </a>
+            </div>
+          </div>
+        </section>
 
-      <section class="container section">
-        <h2 class="center-align">Features</h2>
-        <ul class="collection">
-          <li class="collection-item">
-            <i class="material-icons left green-text text-darken-2"
-              >image_search</i
-            >AI-powered food recognition
-          </li>
-          <li class="collection-item">
-            <i class="material-icons left green-text text-darken-2">person</i
-            >Personalized meal suggestions
-          </li>
-          <li class="collection-item">
-            <i class="material-icons left green-text text-darken-2"
-              >library_books</i
-            >Auto-updated diet diary
-          </li>
-          <li class="collection-item">
-            <i class="material-icons left green-text text-darken-2">spa</i
-            >Nutrition tracker for balance
-          </li>
-        </ul>
-      </section>
+        <section class="container section">
+          <h2 class="center-align">Features<br><span class="grey-text text-darken-1">Ciri-ciri</span></h2>
+          <div class="row">
+            <div class="col s12 m6">
+              <ul class="collection">
+                <li class="collection-item">
+                  <i class="material-icons left green-text text-darken-2">image_search</i>AI-powered food recognition<br><span class="grey-text text-darken-1">Pengenalan makanan berkuasa AI</span>
+                </li>
+                <li class="collection-item">
+                  <i class="material-icons left green-text text-darken-2">person</i>Personalized meal suggestions<br><span class="grey-text text-darken-1">Cadangan makanan diperibadikan</span>
+                </li>
+              </ul>
+            </div>
+            <div class="col s12 m6">
+              <ul class="collection">
+                <li class="collection-item">
+                  <i class="material-icons left green-text text-darken-2">library_books</i>Auto-updated diet diary<br><span class="grey-text text-darken-1">Diari diet dikemas kini secara automatik</span>
+                </li>
+                <li class="collection-item">
+                  <i class="material-icons left green-text text-darken-2">spa</i>Nutrition tracker for balance<br><span class="grey-text text-darken-1">Penjejak pemakanan untuk keseimbangan</span>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </section>
     </main>
 
     <footer class="page-footer grey lighten-3">


### PR DESCRIPTION
## Summary
- shorten the header for better fit on laptop screens
- add Malay translations alongside English text
- place QR code and chat button side by side
- rearrange features section into two columns

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68752cf9a0988323952947fedca94055